### PR TITLE
Add longer window for launch predictions

### DIFF
--- a/lambda/historic_es_to_s3/__init__.py
+++ b/lambda/historic_es_to_s3/__init__.py
@@ -71,7 +71,7 @@ def fetch_s3(serial):
         else:
             raise
 
-def fetch_launch_sites(time_filter="24h"):
+def fetch_launch_sites(time_filter="48h"):
     payload = {
         "aggs": {
             "2": {


### PR DESCRIPTION
I think what's happening is that during one of the opensearch to s3 data upload windows the reverse prediction has fallen out of the window. The updater only looks at the last 24 hours of sondes, however since the prediction occurs at the start of the radiosonde launch it's very likely there is a large window where the reverse prediction is missing. This results in the data not being enriched with the launchsite data and as such looks very much like different data to what we've already uploaded to s3.

https://github.com/projecthorus/pysondehub/issues/9