### PR TITLE
Handle Graw PS-15 sondes

### DIFF
--- a/lambda/sonde_api_to_iot_core/__init__.py
+++ b/lambda/sonde_api_to_iot_core/__init__.py
@@ -260,8 +260,8 @@ def telemetry_filter(telemetry):
     else:
         vaisala_callsign_valid = False
 
-    # Just make sure we're not getting the 'xxxxxxxx' unknown serial from the DFM decoder.
-    if "DFM" in telemetry["type"]:
+    # Just make sure we're not getting the 'xxxxxxxx' unknown serial from the DFM decoder (Which also includes PS-15 pilotsondes)
+    if "DFM" in telemetry["type"] or telemetry["type"] == "PS-15":
         dfm_callsign_valid = "x" not in _serial
     else:
         dfm_callsign_valid = False
@@ -292,14 +292,9 @@ def telemetry_filter(telemetry):
         or ("WxR" in telemetry["type"])
     ):
         _id_msg = "Payload ID %s from Sonde type %s is invalid." % (telemetry["serial"], telemetry["type"])
-        # Add in a note about DFM sondes and their oddness...
-        if "DFM" in telemetry["serial"]:
-            _id_msg += " Note: DFM sondes may take a while to get an ID."
-
-        if "MRZ" in telemetry["serial"]:
-            _id_msg += " Note: MRZ sondes may take a while to get an ID."
 
         return ("errors", _id_msg)
+    
     # https://github.com/projecthorus/sondehub-infra/issues/56
     if "iMet-4" ==  telemetry["type"] or "iMet-1" ==  telemetry["type"]:
         if telemetry["software_name"] == "radiosonde_auto_rx":

--- a/lambda/sonde_api_to_iot_core/__main__.py
+++ b/lambda/sonde_api_to_iot_core/__main__.py
@@ -233,5 +233,16 @@ class TestIngestion(unittest.TestCase):
         self.assertEqual(output["body"], "^v^ telm logged")
         self.assertEqual(output["statusCode"], 200)
 
+    def test_ps15_payload(self):
+        payload = copy.deepcopy(example_body)
+        payload[0]["datetime"] = datetime.datetime.now().isoformat()
+        payload[0]["type"] = "PS-15"
+        payload[0]["subtype"] = "PS-15"
+        payload[0]["serial"] = "21068595"
+        output = lambda_handler(compress_payload(payload), fakeContext())
+        sns.publish.assert_called()
+        self.assertEqual(output["body"], "^v^ telm logged")
+        self.assertEqual(output["statusCode"], 200)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
radiosonde_auto_rx now correctly handles Graw PS-15 pilotsondes (which it wasn't doing before!).
The type for these is PS-15, which requires a change to the serial number checks to allow it.