### PR TITLE
Updates for radiosondy API changes

### DIFF
--- a/lambda/recovery_ingest/__init__.py
+++ b/lambda/recovery_ingest/__init__.py
@@ -39,7 +39,12 @@ def checkExisting(serial, recovered):
 # Attempt to find SondeHub serial for a Radiosony.info serial
 def findSonde(recovery, lat, lon):
     # Get facts to compare against
-    launchTime = datetime.strptime(recovery["start_time"], "%Y-%m-%d %H:%M:%S")
+    if 'Z' in recovery["start_time"]:
+        # Radiosondy.info API update 2026-05
+        # This could be replaced by datetime.fromisoformat in Python >3.11
+        launchTime = datetime.strptime(recovery["start_time"], "%Y-%m-%dT%H:%M:%SZ")
+    else:
+        launchTime = datetime.strptime(recovery["start_time"], "%Y-%m-%d %H:%M:%S")
     sondeType = recovery["radiosonde"]["type"]
     sondeFrequency = recovery["radiosonde"]["qrg"]
 
@@ -93,7 +98,11 @@ def processReports(data):
                 continue
 
             # Import time
-            recovered_time = datetime.strptime(recovery["log_info"]["log_added"], "%Y-%m-%d %H:%M:%S")
+            if 'Z' in recovery["log_info"]["log_added"]:
+                # Radiosondy.info API update 2026-05
+                recovered_time = datetime.strptime(recovery["log_info"]["log_added"], "%Y-%m-%dT%H:%M:%SZ")
+            else:
+                recovered_time = datetime.strptime(recovery["log_info"]["log_added"], "%Y-%m-%d %H:%M:%S")
 
             # Get comment and add attribution
             description = recovery["log_info"]["comment"]


### PR DESCRIPTION
The radiosondy API is changing a little bit, with datetime formats changing to ISO format.

example: 
old value: "log_added": "2026-05-18 15:20:21"
new value: "log_added": "2026-05-18T15:20:21Z"

I've made a change which still uses strptime to parse. We could also use datetime.fromisoformat() if we have Python >=3.11, but I dont know if that will break anything else in the lambdas.