### PR TITLE
Update radiosondy API call with additional type parameter

### DIFF
--- a/lambda/recovery_ingest/__init__.py
+++ b/lambda/recovery_ingest/__init__.py
@@ -10,7 +10,7 @@ searchUrl = "https://api.v2.sondehub.org/sondes"
 
 # Main function
 def handler(event,context):
-    params = "?token={}&period=2".format(config_handler.get("RADIOSONDY","API_KEY"))
+    params = "?token={}&period=2&type=last".format(config_handler.get("RADIOSONDY","API_KEY"))
     url = "https://radiosondy.info/api/v1/sonde-logs{}".format(params)
     response = urllib.request.urlopen(url)
     data = json.load(response)

--- a/lambda/recovery_ingest/test_recovery_ingest.py
+++ b/lambda/recovery_ingest/test_recovery_ingest.py
@@ -57,6 +57,7 @@ class TestRecoveryIngest(unittest.TestCase):
         with unittest.mock.patch('sys.stdout', new = StringIO()): # hide stdout
             recovery_ingest.handler({},{})
 
+        self.assertIn("&type=last",urlopen.call_args_list[0][0][0])
         self.assertEqual(urlopen.call_count, 3)
 
     @patch('traceback.print_exc')


### PR DESCRIPTION
From email:
```
Hi Mark and Michaela.

API endpoint which you're using was modified and changed by your side is needed to deprecate old filtering options.

Currently you use this API call: https://radiosondy.info/api/v1/sonde-logs?token=TOKEN_KEY&period=2

If you want to search by period you need also to add search type=last
https://radiosondy.info/api/v1/sonde-logs?token=TOKEN_KEY&period=2&type=last

Or you can use custom filters documented below:
https://radiosondy.info/api/v1/docs/#/radiosondes/get_sonde_logs

P.S. You can also change authentication method and not pushing token directly in link, but you can use Authorization: Bearer <token> in the HTTP header using the same token key as provided earlier :) 

Best regards,
Michal SQ6KXY
```

.. not sure how to implement the last comment about the token.